### PR TITLE
Reset reconnection count after successful connection

### DIFF
--- a/mattermost.py
+++ b/mattermost.py
@@ -394,7 +394,9 @@ class MattermostBackend(ErrBot):
 		self.bot_identifier = MattermostPerson(self.client, userid=self.client.userid, teamid=self.teamid)
 
 		try:
-			self.client.connect(self.mattermost_event_handler)
+			loop = self.client.connect(self.mattermost_event_handler)
+			self.reset_reconnection_count()
+			loop.run_forever()
 		except KeyboardInterrupt:
 			log.info("Interrupt received, shutting down..")
 			return True

--- a/mattermostclient.py
+++ b/mattermostclient.py
@@ -76,7 +76,7 @@ class MattermostClient:
 	def connect(self, eventHandler):
 		self._loop = asyncio.get_event_loop()
 		self._loop.run_until_complete(self.createConnection(eventHandler))
-		self._loop.run_forever()
+		return self._loop
 
 	@asyncio.coroutine
 	def createConnection(self, eventHandler):


### PR DESCRIPTION
Errbot features builtin reconnection logic which will do exponential
backoff to prevent overloading a network in case of failure. It is
important however to reset the state after a successful connection
because otherwise a second failure will start with a backoff time still
set to what it was the previous time it started reconnecting.