### PR TITLE
Include port into constructed URL

### DIFF
--- a/mattermostclient.py
+++ b/mattermostclient.py
@@ -87,7 +87,11 @@ class MattermostClient:
 		else:
 			scheme = 'ws://'
 
-		url = scheme + self.urlparts.hostname + self.apiUrl + '/users/websocket'
+		port = ''
+		if self.urlparts.port is not None:
+			port = ':' + str(self.urlparts.port)
+
+		url = scheme + self.urlparts.hostname + port + self.apiUrl + '/users/websocket'
 
 		websocket = yield from websockets.connect(
 				url,


### PR DESCRIPTION
The bot is unable to establish connections to mattermost instances on non-standard ports since the port is not included in the construction of the URL for the connection. This commit fixes that.