### PR TITLE
corrects error when threaded mode is enabled

### DIFF
--- a/mattermost.py
+++ b/mattermost.py
@@ -492,7 +492,7 @@ class MattermostBackend(ErrBot):
 		super().prefix_groupchat_reply(message, identifier)
 		message.body = '@{0}: {1}'.format(identifier.nick, message.body)
 
-	def build_reply(self, message, text=None, private=False):
+	def build_reply(self, message, text=None, private=False, threaded=False):
 		response = self.build_message(text)
 		response.frm = self.bot_identifier
 		if private:


### PR DESCRIPTION
When threaded mode is enabled on Errbot, the following st shows upon any reply that Errbot tries to send to mattermost backend.

```
16:27:11 ERROR    errbot.core               Exception in a command filter command.
Traceback (most recent call last):
  File "/home/sokratisg/.errbot-ve/lib/python3.5/site-packages/errbot/core.py", line 336, in process_message
    self.send_simple_reply(msg, reply)
  File "/home/sokratisg/.errbot-ve/lib/python3.5/site-packages/errbot/core.py", line 198, in send_simple_reply
    reply = self.build_reply(msg, text, private=private, threaded=threaded)
TypeError: build_reply() got an unexpected keyword argument 'threaded'
```

Checked the respective slack backend code for this function and it seems this is the way to go for mattermost as well.