### PR TITLE
Person updates

### DIFF
--- a/src/mattermostPerson.py
+++ b/src/mattermostPerson.py
@@ -28,6 +28,11 @@ class MattermostPerson(Person):
         return user["username"]
 
     @property
+    def email(self) -> str:
+        user = self._driver.users.get_user(user_id=self.userid)
+        return user.get("email", "")
+
+    @property
     def teamid(self) -> str:
         return self._teamid
 

--- a/src/mattermostPerson.py
+++ b/src/mattermostPerson.py
@@ -55,14 +55,17 @@ class MattermostPerson(Person):
     @property
     def fullname(self):
         user = self._driver.users.get_user(user_id=self.userid)
-        if "first_name" not in user and "last_name" not in user:
-            log.error("No first or last name for user with ID {}".format(self._userid))
-            return "<{}>".format(self._userid)
-        return "{} {}".format(user["first_name"], user["last_name"])
 
-    @property
-    def person(self):
-        return "@{}".format(self.username)
+        fullname = user.get("first_name", "")
+        if fullname == "":
+            log.warning("No first name for user with ID {}".format(self._userid))
+
+        fullname += " {}".format(user.get("last_name", ""))
+        if fullname == "{} ".format(user.get("first_name", "")):
+            log.warning("No surname for user with ID {}".format(self._userid))
+            fullname.strip()
+
+        return f"{fullname}"
 
     @property
     def person(self):


### PR DESCRIPTION
Adds the `email` property for mattermost.

The `fullname` change will return an empty string if no first name and surname keys are present.  This changes the current behaviour, which returns the user id when first name and surname were not present.

From what I've seen with mattermost v5, even when the user hasn't entered any information in these fields, empty strings are returned. The PR will align `fullname` behaviour in the case of no keys or keys with empty strings.