### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+##  [Unreleased]
+### Added
+### Changed
+### Removed
+
+##  [2.1.0] 2021-11-27
+### Added
+  - create or use thread when sending message with `in_reply_to`.
+  - support of `DIVERT_TO_THREAD` option.
+  - ability to define custom event handlers.
+  - email field to Person object.
+  - cache attributes in order to prevent excessive http requests for Person object.
+  
+### Changed
+  - room occupant no longer processed as list type.
+  - code formatted with black.
+  - message size limt to 16377 characters.
+  - return any combination of first name/surname for Person.fullname without trailing or leading space.
+  - moved project to official errbotio organisation https://github.com/errbotio/errbot-mattermost-backend.git
+  
+### Removed
+
+##  [2.0.2] 2017-11-27
+### Added
+### Changed
+  - channelid to be optional to join a room.
+  
+### Removed

--- a/LICENSE
+++ b/LICENSE
@@ -652,7 +652,8 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    {project}  Copyright (C) {year}  {fullname}
+    err-backend-mattermost  Copyright (C) 2017-2021  Christian Plümer and contributors
+
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/mattermost.plug
+++ b/mattermost.plug
@@ -5,5 +5,5 @@ Module = mattermost
 [Documentation]
 Description = A Mattermost backend for errbot.
 Author = Christian Plümer
-Version = 2.0.2
+Version = 2.1.0
 Website = https://github.com/errbotio/errbot-mattermost-backend


### PR DESCRIPTION
The last mattermost backend release was v2.0.2 in 2017, there have been a few modifications that merit increasing the version t v2.1.0