### PR TITLE
Add py >3.9 compatibility

### DIFF
--- a/src/err-backend-mattermost/err-backend-mattermost.py
+++ b/src/err-backend-mattermost/err-backend-mattermost.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 from functools import lru_cache
@@ -101,8 +100,7 @@ class MattermostBackend(ErrBot):
             self.event_handlers[event] = []
         self.event_handlers[event].append(handler)
 
-    @asyncio.coroutine
-    def mattermost_event_handler(self, payload):
+    async def mattermost_event_handler(self, payload):
         if not payload:
             return
 


### PR DESCRIPTION
asyncio.coroutine got deprecated, since async is available since py37 which is our minimal required version we can just switch to async syntax to support python >3.9

See #60 for details